### PR TITLE
Node/NPM downloader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2084,6 +2084,11 @@
         }
       }
     },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+    },
     "ci-info": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
@@ -2308,8 +2313,7 @@
     "compare-versions": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.2.1.tgz",
-      "integrity": "sha512-2y2nHcopMG/NAyk6vWXlLs86XeM9sik4jmx1tKIgzMi9/RQ2eo758RGpxQO3ErihHmg0RlQITPqgz73y6s7quA==",
-      "dev": true
+      "integrity": "sha512-2y2nHcopMG/NAyk6vWXlLs86XeM9sik4jmx1tKIgzMi9/RQ2eo758RGpxQO3ErihHmg0RlQITPqgz73y6s7quA=="
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -2634,6 +2638,15 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cron-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.5.0.tgz",
+      "integrity": "sha512-gzmXu16/prizIbKPPKJo+WgBpV7k8Rxxu9FgaANW+vx5DebCXavfRqbROjKkr9ETvVPqs+IO+NXj4GG/eLf8zQ==",
+      "requires": {
+        "is-nan": "^1.2.1",
+        "moment-timezone": "^0.5.0"
       }
     },
     "cross-env": {
@@ -3022,7 +3035,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
       "requires": {
         "foreach": "^2.0.5",
         "object-keys": "^1.0.8"
@@ -3031,8 +3043,7 @@
         "object-keys": {
           "version": "1.0.11",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-          "dev": true
+          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
         }
       }
     },
@@ -3352,6 +3363,30 @@
         "rc": "^1.1.2",
         "semver": "^5.3.0",
         "sumchecker": "^1.2.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
       }
     },
     "electron-preferences": {
@@ -4545,8 +4580,7 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -4586,17 +4620,12 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
-    "fs-extra": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-      "dev": true,
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
+        "minipass": "^2.2.1"
       }
     },
     "fs.realpath": {
@@ -6317,6 +6346,14 @@
         "is-path-inside": "^1.0.0"
       }
     },
+    "is-nan": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
+      "integrity": "sha1-n69ltvttskt/XAYoR16nH5iEAeI=",
+      "requires": {
+        "define-properties": "^1.1.1"
+      }
+    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -6531,6 +6568,17 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "isstream": {
@@ -7412,15 +7460,6 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
-    "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -7651,6 +7690,11 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
       "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
       "dev": true
+    },
+    "long-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+      "integrity": "sha1-lyHXiLR+C8taJMLivuGg2lXatRQ="
     },
     "longest": {
       "version": "1.0.1",
@@ -7950,6 +7994,35 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
+    "minipass": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
+      "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "mixin-deep": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
@@ -7975,7 +8048,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -7983,16 +8055,22 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
     "moment": {
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
-      "dev": true
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+    },
+    "moment-timezone": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.17.tgz",
+      "integrity": "sha512-Y/JpVEWIOA9Gho4vO15MTnW1FCmHi3ypprrkUaxsZ1TKg3uqC8q/qMBjTddkHoiwwZN3qvZSr4zJP7x9V3LpXA==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -8083,13 +8161,9 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
     },
     "node-forge": {
       "version": "0.7.5",
@@ -8176,6 +8250,16 @@
         "semver": "^5.4.1",
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
+      }
+    },
+    "node-schedule": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-1.3.0.tgz",
+      "integrity": "sha512-NNwO9SUPjBwFmPh3vXiPVEhJLn4uqYmZYvJV358SRGM06BR4UoIqxJpeJwDDXB6atULsgQA97MfD1zMd5xsu+A==",
+      "requires": {
+        "cron-parser": "^2.4.0",
+        "long-timeout": "0.1.1",
+        "sorted-array-functions": "^1.0.0"
       }
     },
     "normalize-package-data": {
@@ -10129,6 +10213,11 @@
         "asap": "~2.0.3"
       }
     },
+    "promisepipe": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/promisepipe/-/promisepipe-2.1.3.tgz",
+      "integrity": "sha512-pPJRbWEGIuPrjWAdN2lZLRuv+5wMNyig0dniGbMfadS7EK+/kxKqkjAA02iZI+S5Om0tCu6MC1JrjWYs8BlheQ=="
+    },
     "prop-types": {
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
@@ -11415,6 +11504,11 @@
         "is-plain-obj": "^1.0.0"
       }
     },
+    "sorted-array-functions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.1.0.tgz",
+      "integrity": "sha512-zq6fLdGQixb9VZfT/tLgU+LzoedJyTbcf1I/TKETFeUVoWIfcs5HNr+SJSvQJLXRlEZjB1gpILTrxamxAdCcgA=="
+    },
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -11968,6 +12062,32 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
       "dev": true
+    },
+    "tar": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.4.tgz",
+      "integrity": "sha512-mq9ixIYfNF9SK0IS/h2HKMu8Q2iaCuhDDsZhdEag/FHv8fOaYld4vN7ouMgcSSt5WKZzPs8atclTcJm36OTh4w==",
+      "requires": {
+        "chownr": "^1.0.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.3",
+        "minizlib": "^1.1.0",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+        }
+      }
     },
     "term-size": {
       "version": "1.2.0",
@@ -13109,6 +13229,30 @@
       "requires": {
         "fs-extra": "^0.30.0",
         "lodash": ">=3.5 <5"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,15 @@
 	"version": "0.1.0",
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
+		"compare-versions": "3.2.1",
 		"electron-preferences": "1.1.0",
 		"gridicons": "3.0.1",
+		"node-fetch": "2.1.2",
+		"node-schedule": "^1.3.0",
+		"promisepipe": "2.1.3",
 		"react": "16.4.0",
-		"react-dom": "16.4.0"
+		"react-dom": "16.4.0",
+		"tar": "4.4.4"
 	},
 	"homepage": "./",
 	"main": "src/electron-runner.js",

--- a/src/electron-runner.js
+++ b/src/electron-runner.js
@@ -6,6 +6,8 @@ const url = require( 'url' );
 
 const assetsDirectory = path.join( __dirname, '/../assets/' )
 
+const { registerJobs } = require( './services' );
+
 const preferences = new ElectronPreferences( {
 	dataStore: path.resolve( app.getPath( 'userData' ), 'preferences.json' ),
 	defaults: {
@@ -62,8 +64,7 @@ function createWindow() {
 		transparent: true,
 		skipTaskbar: true,
 		webPreferences: {
-		  // Prevents renderer process code from not running when window is
-		  // hidden
+		  // Prevents renderer process code from not running when window is hidden
 		  backgroundThrottling: false,
 		},
 	  } );
@@ -125,6 +126,7 @@ const getWindowPosition = () => {
 app.on( 'ready', () => {
 	createTray();
 	createWindow();
+	registerJobs();
 } );
 
 // Quit when all windows are closed.

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import './index.css';
+
 import WPde from './app';
 import registerServiceWorker from './registerServiceWorker';
+
+import './index.css';
 
 ReactDOM.render( <WPde />, document.getElementById('root') );
 registerServiceWorker();

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,18 @@
+const { mkdirSync, existsSync } = require( 'fs' );
+const { app } = require( 'electron' );
+
+const { registerNodeJob } = require( './node-downloader' );
+
+const TOOLS_DIR = app.getPath( 'userData' ) + '/tools';
+
+const registerJobs = () => {
+	if ( ! existsSync( TOOLS_DIR ) ) {
+		mkdirSync( TOOLS_DIR );
+	}
+
+	registerNodeJob();
+};
+
+module.exports = {
+	registerJobs
+};

--- a/src/services/node-downloader/index.js
+++ b/src/services/node-downloader/index.js
@@ -1,0 +1,80 @@
+const schedule = require( 'node-schedule' );
+const compareVersions = require( 'compare-versions' );
+const { tmpdir } = require( 'os' );
+const fetch = require( 'node-fetch' );
+const { createWriteStream, createReadStream, mkdirSync, existsSync } = require( 'fs' );
+const { app } = require( 'electron' );
+const tar = require( 'tar' );
+const { spawnSync } = require( 'child_process' );
+const promisePipe = require( 'promisepipe' );
+
+const NODE_URL = 'https://nodejs.org/dist/latest-carbon/';
+const PLATFORM = 'darwin-x64';
+const VERSION_REGEX = new RegExp( `href="(node-v([0-9\\.]+)-${ PLATFORM }\\.tar\\.gz)`, 'g' );
+
+const NODE_DIR = app.getPath( 'userData' ) + '/tools/node';
+const NODE_BIN = NODE_DIR + '/bin/node';
+
+function registerJob() {
+	const rule = new schedule.RecurrenceRule();
+	rule.hour = [ 7, 19 ];
+	rule.minute = 0;
+
+	schedule.scheduleJob( rule, checkAndInstallUpdates );
+	checkAndInstallUpdates();
+}
+
+async function checkAndInstallUpdates() {
+	const currentVersion = getLocalVersion();
+	const remoteVersion = await getRemoteVersion();
+
+	if ( compareVersions( remoteVersion.version, currentVersion ) > 0 ) {
+		const fileName = tmpdir() + '/' + remoteVersion.filename;
+
+		// Download
+		const writeFile = createWriteStream(
+			fileName, {
+				encoding: 'binary',
+			} );
+		await fetch( NODE_URL + remoteVersion.filename )
+			.then( ( res ) => promisePipe( res.body, writeFile ) );
+
+		if ( ! existsSync( NODE_DIR ) ) {
+			mkdirSync( NODE_DIR );
+		}
+
+		// Install
+		tar.extract( {
+			file: fileName,
+			cwd: NODE_DIR,
+			strip: 1,
+			onwarn: ( msg ) => console.log( msg ),
+		} );
+	}
+}
+
+function getLocalVersion() {
+	if ( ! existsSync( NODE_BIN ) ) {
+		return '0.0.0';
+	}
+
+	const versionInfo = spawnSync( NODE_BIN, [ '-v' ] );
+
+	return versionInfo.stdout.toString().replace( 'v', '' );
+}
+
+async function getRemoteVersion() {
+	const remotels = await fetch( NODE_URL )
+		.then ( ( res ) => res.text() );
+
+	const versionInfo = VERSION_REGEX.exec( remotels );
+
+	return {
+		version: versionInfo[ 2 ],
+		filename: versionInfo[ 1 ],
+	};
+}
+
+module.exports = {
+	registerNodeJob: registerJob,
+};


### PR DESCRIPTION
To ensure the build environment is controlled, we need to maintain our own copy of Node and NPM, automatically download and install updates, as well as ensure WordPress' `node_modules` is up to date.

- [x] Download and install a controlled copy of Node
- [ ] Download and install a controlled copy of NPM
- [ ] Run `npm install` on the WordPress install, using a controlled NPM cache
- [ ] Watch WordPress' `package.json` for changes, and re-run `npm install`