### PR TITLE
Wrong path used when creating wp-config.php

### DIFF
--- a/src/services/docker/index.js
+++ b/src/services/docker/index.js
@@ -251,7 +251,7 @@ async function installWordPress() {
 			'--dbuser=root',
 			'--dbpass=password',
 			'--dbhost=mysql',
-			'--path=/var/www/html/build' );
+			'--path=/var/www/build' );
 
 		if ( existsSync( cwd + '/build/wp-config.php' ) ) {
 			debug( 'Moving wp-config.php out of the build directory' );


### PR DESCRIPTION
#39 changed the path, but I didn't update where it was used when creating `wp-config.php`.